### PR TITLE
dynamic weighted random case selection and Fix times order

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,6 +42,7 @@ OLL trainer
                 background <input type='text' value='#f5f5f5' class='settinginput' id='bgcolor_in' onchange="applystyle();" placeholder='#f5f5f5' maxlength='12'/>
               , text <input type='text' value='black' class='settinginput' id='textcolor_in' onchange="applystyle();"  placeholder='#000' maxlength='12'/>
               , links <input type='text' value='#004411' class='settinginput' id='linkscolor_in' onchange="applystyle();"  placeholder='#004411' maxlength='12'/>
+              , goal (ms) <input type='number' value = 5000 class='settinginput' id='goal_in' onchange="applygoal();" placeholder=5000 max=10000/> (0 or empty to ignore dynamic weights)
               <br>
 			<span id="last_scramble">
 			Any questions/suggestions/bugs reports - post in <a href="https://www.speedsolving.com/forum/threads/oll-trainer.66924/" target="_blank" class="settings">this thread</a>

--- a/scripts/algsinfo.js
+++ b/scripts/algsinfo.js
@@ -2,6 +2,8 @@ var selCases = [];
 
 var algsOrder = [];
 
+var selCasesWeights = [];
+
 var algsGroups = {
     "All Edges Oriented Correctly" : [26, 27, 21, 22, 24, 25, 23],
     "T-Shapes" : [33, 45],

--- a/scripts/algsinfo.js
+++ b/scripts/algsinfo.js
@@ -1,5 +1,7 @@
 var selCases = [];
 
+var algsOrder = [];
+
 var algsGroups = {
     "All Edges Oriented Correctly" : [26, 27, 21, 22, 24, 25, 23],
     "T-Shapes" : [33, 45],
@@ -16,6 +18,10 @@ var algsGroups = {
     "Lightning Bolts" : [7, 8, 11, 12, 39, 40],
     "No Edges Flipped Correctly" : [1,2,3,4,18,19,17,20],
 };
+
+for (i in algsGroups) {
+    algsOrder = algsOrder.concat(algsGroups[i]);
+}
 
 var algsInfo = {
     1: {

--- a/scripts/saveload.js
+++ b/scripts/saveload.js
@@ -27,7 +27,13 @@ function loadLocal(name, defaultValue) {
     }
 }
 
+function initializeSelCasesWeights() {
+    window.selCasesWeights = new Array(window.selCases.length).fill(1);
+}
+
 function saveSelection() {
+    // we re-initialize the weights on selection change (save)
+    initializeSelCasesWeights();
     return saveLocal('ollSelection', JSON.stringify(window.selCases));
 }
 

--- a/scripts/timer.js
+++ b/scripts/timer.js
@@ -493,6 +493,7 @@ function displayStats()
             var timesString = "";
             var meanForCase = 0.0;
             var i = 0;
+            timesString += "[weight: " + window.selCasesWeights[window.selCases.indexOf(parseInt(oll))] + "] ";
             for (; i < resultsByCase[oll].length; i++)
             {
                 timesString += makeHtmlDisplayableTime(resultsByCase[oll][i]);

--- a/scripts/timer.js
+++ b/scripts/timer.js
@@ -29,6 +29,31 @@ function randomElement(arr)
     return arr[Math.floor(Math.random()*arr.length)];
 }
 
+// https://stackoverflow.com/a/55671924
+function randomWeightedElement(items, weights) {
+    var i;
+    var _w = weights.slice(); // don't want to modify the original weights
+
+    for (i = 1; i < _w.length; i++)
+        _w[i] += _w[i - 1];
+    
+    var random = Math.random() * _w[_w.length - 1];
+    
+    for (i = 0; i < _w.length; i++)
+        if (_w[i] > random)
+            break;
+    
+    return items[i];
+}
+
+function updateSelectedWeights(ms)
+{
+    const goal = 5000; // TODO: expose alg time goal in UI ()
+    const index = window.selCases.indexOf(window.lastCase);
+    if (ms > 5000) window.selCasesWeights[index] *= 2;
+    else window.selCasesWeights[index] /= 2;
+}
+
 function confirmUnsel(i) {
     if (confirm("Do you want to unselect this case?")) {
         var index = window.selCases.indexOf(i);
@@ -62,7 +87,7 @@ function generateScramble()
     // get random case
     var caseNum = 0;
     if (recapArray.length == 0) { // train
-        caseNum = randomElement(window.selCases);
+        caseNum = randomWeightedElement(window.selCases, window.selCasesWeights);
     } else { // recap
         // select the case
         caseNum = randomElement(window.recapArray);
@@ -348,7 +373,9 @@ function escapeHtml(text) {
 function appendStats()
 {
     // assuming the time can be grabbed from timer label, and the case - window.lastCase
-    window.timesArray.push(makeResultInstance());
+    var mri = makeResultInstance();
+    window.timesArray.push(mri);
+    updateSelectedWeights(mri.ms);
     displayStats();
 }
 
@@ -389,6 +416,7 @@ function confirmClear()
 {
     if (confirm("Are you sure you want to clear session?")) {
         window.timesArray = [];
+        initializeSelCasesWeights();
         document.getElementById('infoHeader').innerHTML = ('')
         displayStats();
     }

--- a/scripts/timer.js
+++ b/scripts/timer.js
@@ -453,7 +453,10 @@ function displayStats()
         }
 
         var keys = Object.keys(resultsByCase);
-        keys.sort();
+        keys.sort(function(a, b) {
+            //return parseInt(a) - parseInt(b); // old simple fix numerical order
+            return algsOrder.indexOf(a) - algsOrder.indexOf(b); // new algsinfo ordering
+        });
 
         var s = "";
         // allocate them inside times span

--- a/scripts/timer.js
+++ b/scripts/timer.js
@@ -4,6 +4,7 @@ if (timesArray == null) // todo fix when figure out why JSON.parse("[]") returns
     timesArray = [];
 var lastScramble = "";
 var lastCase = 0;
+var goal = 5000;
 
 displayStats(); // after loading
 
@@ -48,9 +49,9 @@ function randomWeightedElement(items, weights) {
 
 function updateSelectedWeights(ms)
 {
-    const goal = 5000; // TODO: expose alg time goal in UI ()
+    if (isNaN(window.goal) || window.goal == 0) return;
     const index = window.selCases.indexOf(window.lastCase);
-    if (ms > 5000) window.selCasesWeights[index] *= 2;
+    if (ms > window.goal) window.selCasesWeights[index] *= 2;
     else window.selCasesWeights[index] /= 2;
 }
 
@@ -493,7 +494,8 @@ function displayStats()
             var timesString = "";
             var meanForCase = 0.0;
             var i = 0;
-            timesString += "[weight: " + window.selCasesWeights[window.selCases.indexOf(parseInt(oll))] + "] ";
+            if (!isNaN(window.goal) && window.goal > 0) 
+                timesString += "[weight: " + window.selCasesWeights[window.selCases.indexOf(parseInt(oll))] + "] ";
             for (; i < resultsByCase[oll].length; i++)
             {
                 timesString += makeHtmlDisplayableTime(resultsByCase[oll][i]);
@@ -600,6 +602,12 @@ function resetStyle(dark) {
     document.getElementById("linkscolor_in").value = dark ? "#ffff00" : "#004411";
     applystyle();
     savestyle();
+}
+
+function applygoal() {
+    //window.goal = document.getElementById("goal_in").value;
+    window.goal = document.querySelector('#goal_in').valueAsNumber;
+    displayStats();
 }
 
 // add key listeners to blur settings inputs


### PR DESCRIPTION
Two changes included in this PR:

* Each selected case starts with equal probability of being randomly selected (1). After each solve, if the time is faster than the goal, the probability of choosing the same case is halved. Otherwise it's doubled. This way you can train on a few cases and the weighted random selection will gravitate towards those that are still not fully learned (fast enough)
*  The ordering of the practiced cases now follow the same order in which they are defined in code, instead of the incorrect alphanumerical one.