### PR TITLE
fix oll number order in times box

### DIFF
--- a/scripts/algsinfo.js
+++ b/scripts/algsinfo.js
@@ -1,5 +1,7 @@
 var selCases = [];
 
+var algsOrder = [];
+
 var algsGroups = {
     "All Edges Oriented Correctly" : [26, 27, 21, 22, 24, 25, 23],
     "T-Shapes" : [33, 45],
@@ -16,6 +18,10 @@ var algsGroups = {
     "Lightning Bolts" : [7, 8, 11, 12, 39, 40],
     "No Edges Flipped Correctly" : [1,2,3,4,18,19,17,20],
 };
+
+for (i in algsGroups) {
+    algsOrder = algsOrder.concat(algsGroups[i]);
+}
 
 var algsInfo = {
     1: {

--- a/scripts/timer.js
+++ b/scripts/timer.js
@@ -453,7 +453,10 @@ function displayStats()
         }
 
         var keys = Object.keys(resultsByCase);
-        keys.sort();
+        keys.sort(function(a, b) {
+            //return parseInt(a) - parseInt(b); // old simple fix numerical order
+            return algsOrder.indexOf(a) - algsOrder.indexOf(b); // new algsinfo ordering
+        });
 
         var s = "";
         // allocate them inside times span


### PR DESCRIPTION
The ordering of the practiced cases now follow the same order in which they are defined in code, instead of the incorrect alphanumerical one.